### PR TITLE
Add code folding similar to PowerShell #4

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -27,4 +27,10 @@
         "increaseIndentPattern": "(^\\s*(\\b([Cc]lass|[Ee]lse([Ii]f)?|[Ff]or|[Ss]elect|[Cc]ase)\\b|\\b([Ii]f)\\b.*\\b([Tt]hen)\\s*$)|\\b([Pp]roperty|[Ss]ub|[Ff]unction))\\b.*$",
         "decreaseIndentPattern": "^\\s*([Ee]nd|[Ee]lse([Ii]f)?|[Cc]ase|[Nn]ext|[Ll]oop)\\b"
     }
+    "folding": {
+        "markers": {
+            "start": "'region",
+            "end": "'endregion"
+        }
+    }
 }


### PR DESCRIPTION
Allows code-folding, e.g.:

`'region Script Metadata ####################################################`
`' Define the name of this script. It is used in UAC prompts:`
`Const SCRIPT_NAME = _`
`"Enter Your Script Name Here In Quotes"`
`' Description: `
`' Version: 1.0.YYYYMMDD.0`
`' Template Version: 4.0.20201221.0 Alpha`
`' Written by <name>, Frank Lesniak, and Andrew Topp from West Monroe Partners`
`'endregion Script Metadata ####################################################`

This code can be collapsed by clicking on the dropdown that appears next to the start of the first line ('region)